### PR TITLE
fix: update rpc env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-RPC_CHAIN_URL_1=
-RPC_CHAIN_URL_10=
-RPC_CHAIN_URL_8453=
+RPC_URI_FOR_1=
+RPC_URI_FOR_10=
+RPC_URI_FOR_8453=
 
 # The API key to return in responses so Kong can validate
 KONG_SECRET=dev-fapy-key

--- a/src/utils/rpcs.ts
+++ b/src/utils/rpcs.ts
@@ -5,10 +5,10 @@ export const getChainFromChainId = (chainId: number) => {
 };
 
 export function getRPCUrl(chainId: number) {
-  const rpcUrl = process.env[`RPC_CHAIN_URL_${chainId}`];
+  const rpcUrl = process.env[`RPC_URI_FOR_${chainId}`];
 
   if (!rpcUrl) {
-    throw new Error(`RPC URL not set in environment variables for chain ${chainId}`);
+    throw new Error(`RPC_URI_FOR_ not set in environment variables for chain ${chainId}`);
   }
 
   return rpcUrl;


### PR DESCRIPTION
## Description
Update rpc env vars, given using this new naming schema we can share the configs across multiple projects on vercel, making the management much straight forward.