### PR TITLE
Switch webhook to batch payload

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { z } from 'zod';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { KongWebhookSchema, OutputSchema } from '../src/types/schemas';
+import { KongBatchWebhookSchema, OutputSchema } from '../src/types/schemas';
 import { computeFapy } from '../src/output';
 
 function verifyWebhookSignature(
@@ -58,12 +58,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const hook = KongWebhookSchema.parse(req.body);
-
+    const hook = KongBatchWebhookSchema.parse(req.body);
     const outputs = await computeFapy(hook);
-
     const replacer = (_: string, v: unknown) => (typeof v === 'bigint' ? v.toString() : v);
-
     res.status(200).send(JSON.stringify(OutputSchema.array().parse(outputs), replacer));
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/specs/batch-webhook-support.md
+++ b/specs/batch-webhook-support.md
@@ -1,0 +1,148 @@
+# Add Batch Webhook Support to fapy-hook
+
+> Linear: [BE-46](https://linear.app/yearn-webops/issue/BE-46/request-for-spec-estimated-apr-webhook-batching)
+> Depends on: [BE-45](https://linear.app/yearn-webops/issue/BE-45/request-for-spec-kong-webhook-batching) (Kong webhook batching)
+
+## Description
+
+Upgrade fapy-hook to accept batched webhook payloads from Kong, processing multiple vaults in a single HTTP request instead of one vault per request. This reduces HTTP overhead and enables shared data fetching (e.g., Curve gauge/pool data fetched once per chain instead of once per vault).
+
+## Context
+
+**Current implementation:**
+- `api/webhook.ts` receives a single-source payload from Kong with one `chainId`/`address` pair
+- `src/output.ts:computeFapy()` processes one vault: fetches vault + strategies from Kong GraphQL, determines vault type (Curve vs Velodrome), computes APY
+- `src/fapy.ts:computeChainAPY()` calls `fetchGauges()`, `fetchPools()`, `fetchSubgraph()`, `fetchFraxPools()` — these are called for every single vault request even though the data is chain-level, not vault-level
+- `src/service.ts:getVaultWithStrategies()` fetches vault and strategy data from Kong's GraphQL API
+
+**Current single-source payload:**
+```json
+{
+  "abiPath": "yearn/2/vault",
+  "chainId": 1,
+  "address": "0xabc...",
+  "blockNumber": "12345",
+  "blockTime": "67890",
+  "subscription": { "id": "S_C2795BC0", "url": "...", "abiPath": "...", "type": "timeseries", "labels": [...] }
+}
+```
+
+**New batch payload (defined by BE-45):**
+```json
+{
+  "abiPath": "yearn/2/vault",
+  "subscription": { "id": "S_C2795BC0", "url": "...", "abiPath": "...", "type": "timeseries", "labels": [...] },
+  "sources": [
+    { "chainId": 1, "address": "0xabc...", "blockNumber": "12345", "blockTime": "67890" },
+    { "chainId": 1, "address": "0xdef...", "blockNumber": "12345", "blockTime": "67890" },
+    { "chainId": 10, "address": "0x123...", "blockNumber": "99999", "blockTime": "11111" }
+  ]
+}
+```
+
+**Relevant references:**
+- Webhook handler: `api/webhook.ts`
+- Output computation: `src/output.ts`
+- Vault data service: `src/service.ts`
+- APY computation: `src/fapy.ts`
+- Curve data fetcher: `src/crv.fetcher.ts`
+- Velodrome computation: `src/velo-like.forward.ts`
+- Schemas: `src/types/schemas.ts`
+
+## Tasks
+
+### 1. Add Batch Payload Schema
+
+- In `src/types/schemas.ts`, add:
+  ```typescript
+  const SourceSchema = z.object({
+    chainId: z.number(),
+    address: AddressSchema,
+    blockNumber: z.bigint({ coerce: true }),
+    blockTime: z.bigint({ coerce: true }),
+  })
+
+  export const KongBatchWebhookSchema = z.object({
+    abiPath: z.string(),
+    subscription: WebhookSubscriptionSchema,
+    sources: SourceSchema.array(),
+  })
+  export type KongBatchWebhook = z.infer<typeof KongBatchWebhookSchema>
+  ```
+
+### 2. Add Batch Output Computation
+
+- In `src/output.ts`, add a `computeFapyBatch(hook: KongBatchWebhook): Promise<Output[]>` function:
+  - Group `hook.sources` by `chainId`
+  - For each chain group, fetch shared chain data once:
+    - Curve vaults: `fetchGauges()`, `fetchPools()`, `fetchSubgraph(chainId)`, `fetchFraxPools()` — called once per chain, not per vault
+    - Velodrome/Aerodrome vaults: shared chain-level data fetched once
+  - For each source in the group:
+    - Call `getVaultWithStrategies(source.chainId, source.address)` to get vault + strategy data
+    - Compute APY using the shared chain data
+    - Build `Output[]` for this source (same logic as current `computeFapy`)
+  - Concatenate all outputs across all sources
+  - Handle individual source errors gracefully: log the error, skip the failed source, continue processing remaining sources
+
+### 3. Update Webhook Handler
+
+- In `api/webhook.ts`, modify `handler()`:
+  - Detect payload type: check if `req.body.sources` exists
+  - If batch payload: parse with `KongBatchWebhookSchema`, call `computeFapyBatch()`
+  - If single-source payload: parse with `KongWebhookSchema`, call `computeFapy()` (current behavior)
+  - Both paths return `Output[]` in the response
+  - Signature verification remains the same (HMAC of the full body)
+
+### 4. Optimize Shared Data Fetching
+
+- Refactor `src/fapy.ts:computeChainAPY()` to accept pre-fetched chain data as an optional parameter:
+  ```typescript
+  export interface ChainData {
+    gauges: Awaited<ReturnType<typeof fetchGauges>>
+    pools: Awaited<ReturnType<typeof fetchPools>>
+    subgraph: Awaited<ReturnType<typeof fetchSubgraph>>
+    fraxPools: Awaited<ReturnType<typeof fetchFraxPools>>
+  }
+
+  export async function computeChainAPY(
+    vault: GqlVault,
+    chainId: number,
+    strategies: Array<GqlStrategy>,
+    chainData?: ChainData, // optional — fetch if not provided
+  ): Promise<VaultAPY | null>
+  ```
+- When `chainData` is provided, skip fetching and use the pre-fetched data
+- When `chainData` is not provided, fetch as before (backward compatible)
+- In `computeFapyBatch()`, fetch chain data once per chain group and pass it to `computeChainAPY()` for each vault
+
+### 5. Testing
+
+- Add unit tests for:
+  - `KongBatchWebhookSchema` validation (valid batch, empty sources, mixed chains)
+  - `computeFapyBatch()` with multiple sources across chains
+  - `computeFapyBatch()` with partial failures (one source errors, others succeed)
+  - Webhook handler detecting and routing batch vs single payloads
+  - Shared chain data reuse across vaults in same chain group
+- Update existing tests to ensure single-source payloads still work
+
+## Acceptance Criteria
+
+- [ ] Single-source payloads continue to work exactly as before (backward compatible)
+- [ ] Batch payloads with `sources` array are accepted and processed
+- [ ] Each source in a batch produces correct APY outputs with correct labels (`crv-estimated-apr`, `velo-estimated-apr`, `aero-estimated-apr`)
+- [ ] Chain-specific data (gauges, pools, subgraph, fraxPools) is fetched once per chain group, not per vault
+- [ ] Individual source failures don't fail the entire batch — failed sources are skipped with logged errors
+- [ ] Response contains combined `Output[]` from all successfully processed sources
+- [ ] HMAC signature verification works with batch payloads
+- [ ] Tests cover both single and batch flows
+
+## Technical Notes
+
+- **Vercel function timeout**: Vercel functions have a default timeout of 10 seconds (30s on Pro plan). Processing a batch of 50+ vaults may exceed this. Mitigations:
+  - Parallelize vault processing within each chain group using `Promise.allSettled()`
+  - If timeouts persist, Kong can split large batches into smaller chunks (configurable batch size on the Kong side)
+  - Consider increasing the Vercel function timeout via `vercel.json` configuration
+- **Error isolation**: Use `Promise.allSettled()` for per-source processing. Log failures with `console.error` including `chainId` and `address` for debugging. Return outputs only for successful sources.
+- **Memory**: Processing many vaults in a single request increases memory usage. Monitor Vercel function memory limits and adjust if needed.
+- **Backward compatibility**: The webhook must continue accepting single-source payloads indefinitely. Kong's batch mode is opt-in per subscription, and there may always be non-batch subscriptions.
+- **Shared data caching**: The `fetchGauges()` and `fetchPools()` calls in `src/crv.fetcher.ts` are not chain-specific (they return global Curve data). These can be fetched once for the entire batch, not once per chain group. Only `fetchSubgraph(chainId)` is chain-specific.

--- a/src/batch-webhook.test.ts
+++ b/src/batch-webhook.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'node:crypto';
 import { KongBatchWebhookSchema } from './types/schemas';
 
 const VAULT_A = '0xaA00000000000000000000000000000000000001' as `0x${string}`;
@@ -276,7 +277,6 @@ describe('webhook handler', () => {
   });
 
   function makeSignature(body: string, secret = 'test-secret') {
-    const { createHmac } = require('node:crypto');
     const timestamp = Math.floor(Date.now() / 1000);
     const sig = createHmac('sha256', secret).update(`${timestamp}.${body}`, 'utf8').digest('hex');
     return `t=${timestamp},v1=${sig}`;

--- a/src/batch-webhook.test.ts
+++ b/src/batch-webhook.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KongBatchWebhookSchema } from './types/schemas';
+
+const VAULT_A = '0xaA00000000000000000000000000000000000001' as `0x${string}`;
+const VAULT_B = '0xbB00000000000000000000000000000000000002' as `0x${string}`;
+const VAULT_C = '0xCC00000000000000000000000000000000000003' as `0x${string}`;
+const STRATEGY_A = '0xDD00000000000000000000000000000000000004' as `0x${string}`;
+
+const subscription = {
+  id: 'S_TEST',
+  url: 'https://example.com/webhook',
+  abiPath: 'yearn/2/vault',
+  type: 'timeseries' as const,
+  labels: ['crv-estimated-apr'],
+};
+
+// ---- Schema tests ----
+
+describe('KongBatchWebhookSchema', () => {
+  it('parses a valid batch payload', () => {
+    const result = KongBatchWebhookSchema.parse({
+      abiPath: 'yearn/2/vault',
+      blockNumber: '123456',
+      blockTime: '1700000000',
+      subscription,
+      vaults: [
+        { chainId: 1, address: VAULT_A },
+        { chainId: 1, address: VAULT_B },
+        { chainId: 10, address: VAULT_C },
+      ],
+    });
+    expect(result.vaults).toHaveLength(3);
+    expect(result.blockNumber).toBe(123456n);
+  });
+
+  it('coerces blockNumber and blockTime from numbers', () => {
+    const result = KongBatchWebhookSchema.parse({
+      abiPath: 'yearn/2/vault',
+      blockNumber: 999,
+      blockTime: 1000,
+      subscription,
+      vaults: [{ chainId: 1, address: VAULT_A }],
+    });
+    expect(result.blockNumber).toBe(999n);
+  });
+
+  it('rejects invalid address in vaults', () => {
+    expect(() =>
+      KongBatchWebhookSchema.parse({
+        abiPath: 'yearn/2/vault',
+        blockNumber: '1',
+        blockTime: '1',
+        subscription,
+        vaults: [{ chainId: 1, address: 'not-an-address' }],
+      }),
+    ).toThrow();
+  });
+
+  it('rejects missing vaults field', () => {
+    expect(() =>
+      KongBatchWebhookSchema.parse({
+        abiPath: 'yearn/2/vault',
+        blockNumber: '1',
+        blockTime: '1',
+        subscription,
+      }),
+    ).toThrow();
+  });
+});
+
+// ---- computeFapy tests (mocked dependencies) ----
+
+vi.mock('./service', () => ({
+  getVaultsWithStrategies: vi.fn(),
+}));
+
+vi.mock('./fapy', () => ({
+  computeChainAPY: vi.fn(),
+  fetchChainData: vi.fn(),
+}));
+
+vi.mock('./velo-like.forward', () => ({
+  isVeloLikeVault: vi.fn(),
+}));
+
+import { computeFapy } from './output';
+import { getVaultsWithStrategies } from './service';
+import { computeChainAPY, fetchChainData } from './fapy';
+import { isVeloLikeVault } from './velo-like.forward';
+
+const mockVault = (address: string, chainId = 1) => ({
+  chainId,
+  address,
+  asset: { address: '0x0000000000000000000000000000000000000000', chainId, name: 'CRV', symbol: 'CRV', decimals: 18 },
+  strategies: [],
+  debts: [],
+});
+
+const mockFapy = () => ({
+  netAPR: 0.05,
+  netAPY: 0.051,
+  boost: 1.5,
+  poolAPY: 0.03,
+  boostedAPR: 0.04,
+  baseAPR: 0.02,
+  rewardsAPR: 0.01,
+  rewardsAPY: 0.011,
+  cvxAPR: 0.005,
+  keepCRV: 0.1,
+});
+
+const makeHook = (vaults: { chainId: number, address: `0x${string}` }[]) => ({
+  abiPath: 'yearn/2/vault',
+  blockNumber: 100n,
+  blockTime: 200n,
+  subscription,
+  vaults,
+});
+
+describe('computeFapy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isVeloLikeVault).mockResolvedValue([null, false]);
+    vi.mocked(fetchChainData).mockResolvedValue({
+      gauges: [],
+      pools: [],
+      subgraph: [],
+      fraxPools: [],
+    });
+  });
+
+  it('produces outputs for multiple vaults on same chain', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+      [VAULT_B.toLowerCase(), { vault: mockVault(VAULT_B), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    const outputs = await computeFapy(makeHook([
+      { chainId: 1, address: VAULT_A },
+      { chainId: 1, address: VAULT_B },
+    ]));
+
+    // 10 CRV components per vault * 2 vaults = 20
+    expect(outputs).toHaveLength(20);
+    expect(outputs.filter(o => o.address === VAULT_A)).toHaveLength(10);
+    expect(outputs.filter(o => o.address === VAULT_B)).toHaveLength(10);
+    expect(outputs.every(o => o.label === 'crv-estimated-apr')).toBe(true);
+  });
+
+  it('fetches chain data once per chain, not per vault', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+      [VAULT_B.toLowerCase(), { vault: mockVault(VAULT_B), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    await computeFapy(makeHook([
+      { chainId: 1, address: VAULT_A },
+      { chainId: 1, address: VAULT_B },
+    ]));
+
+    expect(fetchChainData).toHaveBeenCalledTimes(1);
+    expect(fetchChainData).toHaveBeenCalledWith(1);
+  });
+
+  it('groups vaults by chain and fetches data per chain', async () => {
+    const chain1Map = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A, 1), strategies: [] }],
+    ]);
+    const chain10Map = new Map([
+      [VAULT_C.toLowerCase(), { vault: mockVault(VAULT_C, 10), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies)
+      .mockResolvedValueOnce(chain1Map as any)
+      .mockResolvedValueOnce(chain10Map as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    await computeFapy(makeHook([
+      { chainId: 1, address: VAULT_A },
+      { chainId: 10, address: VAULT_C },
+    ]));
+
+    expect(getVaultsWithStrategies).toHaveBeenCalledTimes(2);
+    expect(fetchChainData).toHaveBeenCalledTimes(2);
+    expect(fetchChainData).toHaveBeenCalledWith(1);
+    expect(fetchChainData).toHaveBeenCalledWith(10);
+  });
+
+  it('passes pre-fetched chainData to computeChainAPY', async () => {
+    const chainData = { gauges: ['g'], pools: ['p'], subgraph: ['s'], fraxPools: ['f'] };
+    vi.mocked(fetchChainData).mockResolvedValue(chainData as any);
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    await computeFapy(makeHook([{ chainId: 1, address: VAULT_A }]));
+
+    expect(computeChainAPY).toHaveBeenCalledWith(
+      expect.anything(), 1, expect.anything(), chainData,
+    );
+  });
+
+  it('skips failed vaults without failing the batch', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+      [VAULT_B.toLowerCase(), { vault: mockVault(VAULT_B), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY)
+      .mockRejectedValueOnce(new Error('RPC error'))
+      .mockResolvedValueOnce(mockFapy());
+
+    const outputs = await computeFapy(makeHook([
+      { chainId: 1, address: VAULT_A },
+      { chainId: 1, address: VAULT_B },
+    ]));
+
+    expect(outputs).toHaveLength(10);
+    expect(outputs.every(o => o.address === VAULT_B)).toBe(true);
+  });
+
+  it('skips vaults not found in the GraphQL response', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    const outputs = await computeFapy(makeHook([
+      { chainId: 1, address: VAULT_A },
+      { chainId: 1, address: VAULT_B },
+    ]));
+
+    expect(outputs).toHaveLength(10);
+    expect(outputs.every(o => o.address === VAULT_A)).toBe(true);
+  });
+
+  it('returns empty array for empty vaults', async () => {
+    const outputs = await computeFapy(makeHook([]));
+    expect(outputs).toHaveLength(0);
+  });
+
+  it('includes strategy outputs with debtRatio component', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [{ address: STRATEGY_A }] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue({
+      ...mockFapy(),
+      strategies: [{ address: STRATEGY_A, netAPR: 0.04, debtRatio: 5000 }],
+    });
+
+    const outputs = await computeFapy(makeHook([{ chainId: 1, address: VAULT_A }]));
+
+    const stratOutputs = outputs.filter(o => o.address === STRATEGY_A);
+    expect(stratOutputs.length).toBe(11); // 10 CRV components + debtRatio
+    expect(stratOutputs.some(o => o.component === 'debtRatio')).toBe(true);
+  });
+});
+
+// ---- Webhook handler tests ----
+
+describe('webhook handler', () => {
+  let handler: typeof import('../api/webhook').default;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.KONG_SECRET = 'test-secret';
+    const mod = await import('../api/webhook');
+    handler = mod.default;
+  });
+
+  function makeSignature(body: string, secret = 'test-secret') {
+    const { createHmac } = require('node:crypto');
+    const timestamp = Math.floor(Date.now() / 1000);
+    const sig = createHmac('sha256', secret).update(`${timestamp}.${body}`, 'utf8').digest('hex');
+    return `t=${timestamp},v1=${sig}`;
+  }
+
+  function mockReqRes(body: any) {
+    const bodyStr = JSON.stringify(body);
+    const req = {
+      method: 'POST',
+      headers: { 'kong-signature': makeSignature(bodyStr) },
+      body,
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+    return { req, res };
+  }
+
+  it('processes batch payload and returns 200', async () => {
+    const vaultsMap = new Map([
+      [VAULT_A.toLowerCase(), { vault: mockVault(VAULT_A), strategies: [] }],
+    ]);
+    vi.mocked(getVaultsWithStrategies).mockResolvedValue(vaultsMap as any);
+    vi.mocked(computeChainAPY).mockResolvedValue(mockFapy());
+
+    const body = {
+      abiPath: 'yearn/2/vault',
+      blockNumber: '100',
+      blockTime: '200',
+      subscription,
+      vaults: [{ chainId: 1, address: VAULT_A }],
+    };
+    const { req, res } = mockReqRes(body);
+
+    await handler(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(getVaultsWithStrategies).toHaveBeenCalled();
+  });
+
+  it('rejects requests without signature', async () => {
+    const req = { method: 'POST', headers: {}, body: {} };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() };
+
+    await handler(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 400 for invalid payload', async () => {
+    const body = { invalid: true };
+    const { req, res } = mockReqRes(body);
+
+    await handler(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/src/clients/kongClient.ts
+++ b/src/clients/kongClient.ts
@@ -76,6 +76,65 @@ export class KongClient {
   }
 
   /**
+   * Fetch multiple vaults by chainId and addresses.
+   */
+  async getVaults(chainId: number, addresses: `0x${string}`[]): Promise<GqlVault[]> {
+    const query = gql`
+      query Vaults($addresses: [String], $chainId: Int) {
+        vaults(addresses: $addresses, chainId: $chainId) {
+          accountant
+          activation
+          address
+          apiVersion
+          asset {
+            address
+            chainId
+            decimals
+            name
+            symbol
+          }
+          debts {
+            debtRatio
+            strategy
+            performanceFee
+          }
+          creditAvailable
+          debtOutstanding
+          debtRatio
+          decimals
+          depositLimit
+          guardian
+          management
+          managementFee
+          maxAvailableShares
+          name
+          performanceFee
+          pricePerShare
+          expectedReturn
+          rewards
+          symbol
+          token
+          totalAssets
+          totalDebt
+          totalIdle
+          totalSupply
+          strategies
+          yearn
+        }
+      }
+    `;
+    const res = await graphqlRequest<{ vaults: GqlVault[] }>({
+      url: this.url,
+      headers: this.headers,
+      query,
+      variables: { chainId, addresses },
+      throwOnError: false,
+    });
+    if ('errors' in res) return [];
+    return res.data.vaults ?? [];
+  }
+
+  /**
    * Fetch a strategy by chainId and address.
    */
   async getStrategy(chainId: number, address: `0x${string}`): Promise<GqlStrategy | null> {
@@ -114,6 +173,47 @@ query Strategy($chainId: Int, $address: String) {
     });
     if ('errors' in res) return null;
     return res.data.strategy;
+  }
+
+  /**
+   * Fetch all strategies for a chain.
+   */
+  async getStrategiesByChain(chainId: number): Promise<GqlStrategy[]> {
+    const query = gql`
+      query Strategies($chainId: Int) {
+        strategies(chainId: $chainId) {
+          crv
+          apiVersion
+          address
+          symbol
+          name
+          rewards
+          gauge
+          keeper
+          totalDebt
+          totalDebtUsd
+          totalIdle
+          localKeepCRV
+          performanceFee
+          totalAssets
+          totalSupply
+          decimals
+          management
+          pricePerShare
+          want
+          vault
+        }
+      }
+    `;
+    const res = await graphqlRequest<{ strategies: GqlStrategy[] }>({
+      url: this.url,
+      headers: this.headers,
+      query,
+      variables: { chainId },
+      throwOnError: false,
+    });
+    if ('errors' in res) return [];
+    return res.data.strategies ?? [];
   }
 
   /**

--- a/src/fapy.test.ts
+++ b/src/fapy.test.ts
@@ -169,31 +169,32 @@ describe('Calculate FAPY', () => {
         }
 
         it('processes multiple vaults and produces outputs for each', async () => {
-            const vaults = [
-                { chainId: 1, address: '0x8A5f20dA6B393fE25aCF1522C828166D22eF8321' as `0x${string}` },
-                { chainId: 1, address: '0x790a60024bC3aea28385b60480f15a0771f26D09' as `0x${string}` },
+            const addresses = [
+                '0x8A5f20dA6B393fE25aCF1522C828166D22eF8321' as `0x${string}`,
+                '0x790a60024bC3aea28385b60480f15a0771f26D09' as `0x${string}`,
             ]
 
             const outputs = await computeFapy({
                 abiPath: 'yearn/2/vault',
+                chainId: 1,
                 blockNumber: 0n,
                 blockTime: 0n,
                 subscription,
-                vaults,
+                vaults: addresses,
             })
 
             // Each vault should produce outputs
-            const vault1Outputs = outputs.filter(o => o.address.toLowerCase() === vaults[0].address.toLowerCase())
-            const vault2Outputs = outputs.filter(o => o.address.toLowerCase() === vaults[1].address.toLowerCase())
+            const vault1Outputs = outputs.filter(o => o.address.toLowerCase() === addresses[0].toLowerCase())
+            const vault2Outputs = outputs.filter(o => o.address.toLowerCase() === addresses[1].toLowerCase())
 
             expect(vault1Outputs.length).toBeGreaterThan(0)
             expect(vault2Outputs.length).toBeGreaterThan(0)
             expect(outputs.every(o => o.label === 'crv-estimated-apr')).toBe(true)
 
             // Verify outputs match what computeVaultFapy produces
-            for (const vault of vaults) {
-                const fapy = await computeVaultFapy(vault.chainId, vault.address)
-                const vaultOutputs = outputs.filter(o => o.address.toLowerCase() === vault.address.toLowerCase() && o.component === 'netAPY')
+            for (const address of addresses) {
+                const fapy = await computeVaultFapy(1, address)
+                const vaultOutputs = outputs.filter(o => o.address.toLowerCase() === address.toLowerCase() && o.component === 'netAPY')
                 expect(vaultOutputs.length).toBeGreaterThan(0)
                 expectCloseTo(vaultOutputs[0].value ?? 0, fapy?.netAPY ?? 0, 0.01)
             }

--- a/src/output.ts
+++ b/src/output.ts
@@ -129,5 +129,5 @@ export async function computeFapy(hook: KongBatchWebhook): Promise<Output[]> {
     }
   }
 
-  return OutputSchema.array().parse(outputs);
+  return outputs;
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -26,13 +26,11 @@ export type KongWebhook = z.infer<typeof KongWebhookSchema>;
 
 export const KongBatchWebhookSchema = z.object({
   abiPath: z.string(),
+  chainId: z.number(),
   blockNumber: z.bigint({ coerce: true }),
   blockTime: z.bigint({ coerce: true }),
   subscription: WebhookSubscriptionSchema,
-  vaults: z.array(z.object({
-    chainId: z.number(),
-    address: AddressSchema,
-  })),
+  vaults: z.array(AddressSchema),
 });
 export type KongBatchWebhook = z.infer<typeof KongBatchWebhookSchema>;
 

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -24,6 +24,18 @@ export const KongWebhookSchema = z.object({
 });
 export type KongWebhook = z.infer<typeof KongWebhookSchema>;
 
+export const KongBatchWebhookSchema = z.object({
+  abiPath: z.string(),
+  blockNumber: z.bigint({ coerce: true }),
+  blockTime: z.bigint({ coerce: true }),
+  subscription: WebhookSubscriptionSchema,
+  vaults: z.array(z.object({
+    chainId: z.number(),
+    address: AddressSchema,
+  })),
+});
+export type KongBatchWebhook = z.infer<typeof KongBatchWebhookSchema>;
+
 export const OutputSchema = z.object({
   chainId: z.number(),
   address: AddressSchema,


### PR DESCRIPTION
### Summary

Upgrade the webhook to accept batched payloads from Kong, processing multiple vaults in a single HTTP request instead of one vault per request. This reduces HTTP overhead and enables shared data fetching — Curve gauge/pool data is fetched once per chain instead of once per vault.

Closes https://linear.app/yearn-webops/issue/BE-53/fapy-switch-webhook-handler-to-batch-payload

### How to review

Start with the new schema in `src/types/schemas.ts` (`KongBatchWebhookSchema`), then follow the data flow:

1. **`api/webhook.ts`** — now parses the batch schema directly
2. **`src/output.ts`** — `computeFapy()` groups vaults by chain, fetches shared chain data once, processes each vault via `Promise.allSettled()` for error isolation
3. **`src/service.ts`** — new `getVaultsWithStrategies()` fetches all vaults + strategies for a chain in 2 GraphQL queries (vs N+1 before)
4. **`src/fapy.ts`** — extracted `fetchChainData()` and `ChainData` interface; `computeChainAPY()` accepts optional pre-fetched chain data
5. **`src/clients/kongClient.ts`** — new `getVaults()` and `getStrategiesByChain()` batch GraphQL queries

Tests in `src/batch-webhook.test.ts` cover schema validation, batch processing, error isolation, and webhook handler integration.

### Test plan

- [ ] `npx vitest run src/batch-webhook.test.ts` — unit tests for schema, batch output computation, and webhook handler
- [ ] `npx vitest run src/fapy.test.ts` — integration tests including new `computeFapy (batch)` suite that validates against live Kong data
- [ ] Manual: send a batch payload to the local webhook and verify combined `Output[]` response

### Risk / impact

- **Breaking change**: The webhook handler now only accepts the batch schema (`KongBatchWebhookSchema`). Kong must send the new batch format. The old single-source format is no longer accepted.
- **GraphQL queries**: New `getVaults` and `getStrategiesByChain` queries assume Kong's GraphQL API supports `vaults(addresses:)` and `strategies(chainId:)`. Verify these are available in production.
- **Vercel timeout**: Large batches (50+ vaults) may approach function timeout limits. Kong can mitigate by splitting into smaller batches.

