### PR TITLE
fix: skip killed gauges and guard zero working supply

### DIFF
--- a/src/crv-like.forward.ts
+++ b/src/crv-like.forward.ts
@@ -433,6 +433,9 @@ export async function calculateGaugeBaseAPR(
   );
   const secondsPerYear = new Float(31556952); // Match Go exactly
   const workingSupply = toNormalizedAmount(new BigNumberInt(gauge.gauge_data.working_supply), 18);
+  if (workingSupply.isZero()) {
+    return { baseAPY: new Float(0), baseAPR: new Float(0) };
+  }
   const perMaxBoost = new Float(0.4);
 
   const crvPrice = crvTokenPrice instanceof Float ? crvTokenPrice : new Float(crvTokenPrice);
@@ -534,6 +537,7 @@ export async function computeCurveLikeForwardAPY({
   const vaultAsset = vault.asset?.address as `0x${string}`;
   const gauge = findGaugeForVault(vaultAsset, gauges);
   if (!gauge) return { type: '', netAPY: 0 };
+  if (gauge.is_killed || gauge.hasNoCrv) return { type: '', netAPY: 0 };
   const pool = findPoolForVault(vaultAsset, pools);
   const fraxPool = findFraxPoolForVault(vaultAsset, fraxPools);
   const subgraphItem = findSubgraphItemForVault(gauge.swap, subgraphData);


### PR DESCRIPTION
## Summary

- **Skip killed/dead gauges**: `computeCurveLikeForwardAPY` now returns `{ type: '', netAPY: 0 }` when `gauge.is_killed` or `gauge.hasNoCrv` is true, preventing APR computation on gauges that Curve has removed
- **Guard zero working supply**: `calculateGaugeBaseAPR` returns zero APR/APY when `workingSupply` is zero, preventing division-by-zero that produced absurd values
- **Tests**: 3 new test cases covering both guards

## Context

Vault `0x468C76f16B7735303f7215b3839D270d058b3d7a` (Curve eUSD-FRAXBP Factory yVault, V2, chain 1) was showing estimated APR/APY of `3.26e+31`. The vault has ~$38 TVL and 0% historical APY.

**Root cause**: The Curve gauge for eUSD-FRAXBP was killed/removed. When the gauge existed with tiny `workingSupply`, the APR calculation used it as a denominator producing an absurd `boostedAPR` (~14,000%), which compounded to `3.26e+31` via `(1 + 140/52)^52`.

The `Gauge` type already has `is_killed` and `hasNoCrv` fields — they just weren't being checked before computing APR.

## Changes

### `src/crv-like.forward.ts`

1. **`computeCurveLikeForwardAPY`** (line 540): Early return after `findGaugeForVault()` when gauge is killed or has no CRV rewards
2. **`calculateGaugeBaseAPR`** (lines 436-438): Early return with zero APR/APY when normalized `workingSupply` is zero

### `src/crv-like.forward.test.ts`

3 new tests:
- `computeCurveLikeForwardAPY returns zero for killed gauge`
- `computeCurveLikeForwardAPY returns zero for gauge with hasNoCrv`
- `calculateGaugeBaseAPR returns zero when working supply is zero`

## Test plan

- [x] All 3 new tests pass
- [x] Existing tests unaffected (1 pre-existing failure in `determineCurveKeepCRV` unrelated to these changes)
- [ ] After deploy: verify vault `0x468C76f16B7735303f7215b3839D270d058b3d7a` no longer produces absurd estimated APR

> **Note**: A companion change in Kong adds a 7-day freshness TTL on estimated APR queries so stale data is no longer served indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)