### PR TITLE
fix: omit unavailable APY/APR instead of returning zero

### DIFF
--- a/src/batch-webhook.test.ts
+++ b/src/batch-webhook.test.ts
@@ -239,8 +239,10 @@ describe('computeFapy', () => {
     const outputs = await computeFapy(makeHook(1, [VAULT_A]));
 
     const stratOutputs = outputs.filter(o => o.address === STRATEGY_A);
-    expect(stratOutputs.length).toBe(11); // 10 CRV components + debtRatio
     expect(stratOutputs.some(o => o.component === 'debtRatio')).toBe(true);
+    expect(stratOutputs.some(o => o.component === 'netAPR')).toBe(true);
+    // Only components with non-null values are included
+    expect(stratOutputs.length).toBe(2); // netAPR + debtRatio
   });
 });
 

--- a/src/crv-like.forward.test.ts
+++ b/src/crv-like.forward.test.ts
@@ -136,7 +136,7 @@ describe('crv-like.forward core helpers', () => {
     expect(result2).toBeLessThan(0.106)
   })
 
-  it('computeCurveLikeForwardAPY returns zero for killed gauge', async () => {
+  it('computeCurveLikeForwardAPY returns null for killed gauge', async () => {
     const killedGauge: any = {
       gauge: '0xGauge',
       swap: '0xSwap',
@@ -156,10 +156,10 @@ describe('crv-like.forward core helpers', () => {
       chainId: 1,
     })
 
-    expect(result).toEqual({ type: '', netAPY: 0 })
+    expect(result).toBeNull()
   })
 
-  it('computeCurveLikeForwardAPY returns zero for gauge with hasNoCrv', async () => {
+  it('computeCurveLikeForwardAPY returns null for gauge with hasNoCrv', async () => {
     const noCrvGauge: any = {
       gauge: '0xGauge',
       swap: '0xSwap',
@@ -179,7 +179,7 @@ describe('crv-like.forward core helpers', () => {
       chainId: 1,
     })
 
-    expect(result).toEqual({ type: '', netAPY: 0 })
+    expect(result).toBeNull()
   })
 
   it('calculateGaugeBaseAPR returns zero when working supply is zero', async () => {

--- a/src/crv-like.forward.ts
+++ b/src/crv-like.forward.ts
@@ -532,12 +532,12 @@ export async function computeCurveLikeForwardAPY({
   fraxPools: FraxPool[];
   allStrategiesForVault: GqlStrategy[];
   chainId: number;
-}): Promise<VaultAPY> {
+}): Promise<VaultAPY | null> {
   // Match kong logic: use vault.defaults.asset directly
   const vaultAsset = vault.asset?.address as `0x${string}`;
   const gauge = findGaugeForVault(vaultAsset, gauges);
-  if (!gauge) return { type: '', netAPY: 0 };
-  if (gauge.is_killed || gauge.hasNoCrv) return { type: '', netAPY: 0 };
+  if (!gauge) return null;
+  if (gauge.is_killed || gauge.hasNoCrv) return null;
   const pool = findPoolForVault(vaultAsset, pools);
   const fraxPool = findFraxPoolForVault(vaultAsset, fraxPools);
   const subgraphItem = findSubgraphItemForVault(gauge.swap, subgraphData);

--- a/src/output.ts
+++ b/src/output.ts
@@ -59,32 +59,38 @@ async function computeVaultOutputs(
     components = CRV_COMPONENTS;
   }
 
-  const outputs: Output[] = components.map((component) =>
-    OutputSchema.parse({
+  const outputs: Output[] = [];
+
+  for (const component of components) {
+    const value = fapy[component as keyof typeof fapy];
+    if (value == null) continue;
+    outputs.push(OutputSchema.parse({
       chainId,
       address,
       label,
       component,
-      value: fapy[component as keyof typeof fapy] ?? 0,
+      value,
       blockNumber,
       blockTime,
-    }),
-  );
+    }));
+  }
 
   if (fapy.strategies) {
     for (const strategy of fapy.strategies) {
       const strategyComponents = [...components, 'debtRatio'];
-      outputs.push(...strategyComponents.map((component) =>
-        OutputSchema.parse({
+      for (const component of strategyComponents) {
+        const value = strategy[component as keyof typeof strategy];
+        if (value == null) continue;
+        outputs.push(OutputSchema.parse({
           chainId,
           address: strategy.address as `0x${string}`,
           label,
           component,
-          value: strategy[component as keyof typeof strategy] ?? 0,
+          value,
           blockNumber,
           blockTime,
-        }),
-      ));
+        }));
+      }
     }
   }
 

--- a/src/velo-like.forward.test.ts
+++ b/src/velo-like.forward.test.ts
@@ -261,16 +261,17 @@ describe('velo-like.forward core helpers', () => {
         chainId: 10,
       })
 
-      expect(result.type).toContain('v2:velo')
+      expect(result).not.toBeNull()
+      expect(result!.type).toContain('v2:velo')
       expect(result).toHaveProperty('netAPY')
       expect(result).toHaveProperty('keepVelo')
-      expect(result.strategies).toHaveLength(2)
+      expect(result!.strategies).toHaveLength(2)
 
-      const s1 = result.strategies![0]
+      const s1 = result!.strategies![0]
       expect(s1.address).toBe(strategies[0].address)
       expect(s1.debtRatio).toBe(0.5)
 
-      const s2 = result.strategies![1]
+      const s2 = result!.strategies![1]
       expect(s2.address).toBe(strategies[1].address)
       expect(s2.debtRatio).toBe(0.5)
     })
@@ -306,8 +307,9 @@ describe('velo-like.forward core helpers', () => {
       })
 
       expect(mockMulticall).toHaveBeenCalledTimes(1)
-      expect(result.strategies).toHaveLength(1)
-      const strategy = result.strategies![0]
+      expect(result).not.toBeNull()
+      expect(result!.strategies).toHaveLength(1)
+      const strategy = result!.strategies![0]
       expect(strategy.address).toBe(strategies[1].address)
       expect(strategy.debtRatio).toBe(1) // 10000 bps -> 1.0 (normalized)
       expect(strategy.netAPY).toBeGreaterThan(0)

--- a/src/velo-like.forward.test.ts
+++ b/src/velo-like.forward.test.ts
@@ -196,7 +196,7 @@ describe('velo-like.forward core helpers', () => {
   })
 
   describe('computeVeloLikeForwardAPY', () => {
-    it('returns empty result when no asset address', async () => {
+    it('returns null when no asset address', async () => {
       const vault: any = { asset: null }
       const strategies: any[] = []
 
@@ -206,11 +206,10 @@ describe('velo-like.forward core helpers', () => {
         chainId: 10,
       })
 
-      expect(result.type).toBe('')
-      expect(result.netAPY).toBe(0)
+      expect(result).toBeNull()
     })
 
-    it('returns empty result when not a velo-like vault', async () => {
+    it('returns null when not a velo-like vault', async () => {
       const vault: any = { asset: { address: hex('0xAsset') } }
       const strategies: any[] = []
 
@@ -222,8 +221,7 @@ describe('velo-like.forward core helpers', () => {
         chainId: 10,
       })
 
-      expect(result.type).toBe('')
-      expect(result.netAPY).toBe(0)
+      expect(result).toBeNull()
     })
 
     it('aggregates APY from multiple strategies', async () => {

--- a/src/velo-like.forward.ts
+++ b/src/velo-like.forward.ts
@@ -284,15 +284,15 @@ export async function computeVeloLikeForwardAPY({
   vault: GqlVault;
   allStrategiesForVault: GqlStrategy[];
   chainId: number;
-}): Promise<VaultAPY> {
+}): Promise<VaultAPY | null> {
   const assetAddress = vault.asset?.address as `0x${string}`;
   if (!assetAddress) {
-    return { type: '', netAPY: 0 };
+    return null;
   }
 
   const [gaugeAddress, isVeloLike] = await isVeloLikeVault(chainId, assetAddress);
   if (!isVeloLike || !gaugeAddress) {
-    return { type: '', netAPY: 0 };
+    return null;
   }
 
   let typeOf = '';


### PR DESCRIPTION
## Summary

- Return `null` instead of `{ type: '', netAPY: 0 }` from `computeCurveLikeForwardAPY` and `computeVeloLikeForwardAPY` when no valid APY data is available (killed gauge, no CRV, no gauge found, no asset)
- Filter out `null`/`undefined` component values in `computeVaultOutputs` instead of defaulting them to `0` — only components with actual computed values are sent to the webhook consumer
- This prevents the webhook from setting `netAPY: 0` / `netAPR: 0` on vaults where no APR calculation is possible

### Test plan

- [ ] Run tests
```
npm test
```
Expected: all 66 tests pass

- [ ] Verify killed gauge returns null (no output), not zero
```
npm test -- --reporter=verbose 2>&1 | grep -A1 "killed gauge"
```
Expected: `computeCurveLikeForwardAPY returns null for killed gauge` passes

- [ ] Verify hasNoCrv returns null
```
npm test -- --reporter=verbose 2>&1 | grep -A1 "hasNoCrv"
```
Expected: `computeCurveLikeForwardAPY returns null for gauge with hasNoCrv` passes

- [ ] Verify velo null returns
```
npm test -- --reporter=verbose 2>&1 | grep -A1 "returns null"
```
Expected: `returns null when no asset address` and `returns null when not a velo-like vault` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)