### PR TITLE
fix: ignore expired convex reward rates

### DIFF
--- a/src/crv-like.forward.test.ts
+++ b/src/crv-like.forward.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it, vi, expect } from 'vitest'
 import { Float } from './helpers/bignumber-float'
-import { calculateGaugeBaseAPR, computeCurveLikeForwardAPY, determineCurveKeepCRV, getPoolWeeklyAPY, getRewardsAPY } from './crv-like.forward'
+import { calculateGaugeBaseAPR, computeCurveLikeForwardAPY, determineCurveKeepCRV, getCVXPoolAPY, getPoolWeeklyAPY, getRewardsAPY } from './crv-like.forward'
 import * as forwardAPY from './crv-like.forward'
 import * as helpers from './helpers'
 import { convertFloatAPRToAPY } from './helpers/calculation.helper'
@@ -42,6 +42,8 @@ describe('crv-like.forward core helpers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
+    process.env.RPC_URI_FOR_1 = 'http://localhost:8545'
   })
 
   it('determineCurveKeepCRV prefers strategy.localKeepCRV when present', async () => {
@@ -82,6 +84,29 @@ describe('crv-like.forward core helpers', () => {
     const res = getRewardsAPY(pool)
     const [num] = (res as any).toFloat64()
     expect(num).toBeCloseTo(0.05, 1e-9) // 1.5% + 3.5% = 5% -> 0.05
+  })
+
+  it('getCVXPoolAPY ignores expired Convex rewards periods', async () => {
+    const nowSeconds = 1_780_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(nowSeconds * 1000)
+
+    mockReadContract
+      .mockResolvedValueOnce(BigInt(387))
+      .mockResolvedValueOnce(['0xLP', '0xGauge', '0xToken', '0xRewards'])
+      .mockResolvedValueOnce(BigInt('582199014705081'))
+      .mockResolvedValueOnce(BigInt('219760210359908782'))
+      .mockResolvedValueOnce(BigInt(nowSeconds - 1))
+
+    vi.spyOn(helpers, 'getCVXForCRV' as any).mockResolvedValueOnce(new Float(1))
+
+    const result = await getCVXPoolAPY(1, hex('0xStrategy'), new Float(1))
+
+    expect(result.crvAPR.isZero()).toBe(true)
+    expect(result.cvxAPR.isZero()).toBe(true)
+    expect(result.crvAPY.isZero()).toBe(true)
+    expect(result.cvxAPY.isZero()).toBe(true)
+    expect(helpers.getCVXForCRV).not.toHaveBeenCalled()
   })
 
   it('calculateCurveForwardAPY composes pieces', async () => {

--- a/src/crv-like.forward.ts
+++ b/src/crv-like.forward.ts
@@ -147,7 +147,7 @@ export async function getCVXPoolAPY(
       return { crvAPR, cvxAPR, crvAPY, cvxAPY };
     }
 
-    const [rateResult, totalSupply] = (await Promise.all([
+    const [rateResult, totalSupply, periodFinish] = (await Promise.all([
       client.readContract({
         address: crvRewardsAddress,
         abi: crvRewardsAbi,
@@ -160,7 +160,17 @@ export async function getCVXPoolAPY(
         functionName: 'totalSupply',
         args: [],
       }),
-    ])) as [bigint, bigint];
+      client.readContract({
+        address: crvRewardsAddress,
+        abi: crvRewardsAbi,
+        functionName: 'periodFinish',
+        args: [],
+      }),
+    ])) as [bigint, bigint, bigint];
+
+    if (periodFinish <= BigInt(Math.floor(Date.now() / 1000))) {
+      return { crvAPR, cvxAPR, crvAPY, cvxAPY };
+    }
 
     const rate = toNormalizedAmount(new BigNumberInt(rateResult), 18);
     const supply = toNormalizedAmount(new BigNumberInt(totalSupply), 18);


### PR DESCRIPTION
## Summary
- Stop annualizing stale Convex `rewardRate` values after a rewards contract has passed `periodFinish`.
- Return zero CRV/CVX APR/APY for expired Convex rewards periods.
- Add a regression test covering the expired-rewards case and ensuring CVX mint APR math is skipped.

## Context
A Curve/Convex vault was showing an impossible estimated APY (~100k%+) in Kong/Powerglove. The bad value was already present in Kong's `crv-estimated-apr` output, so this was not a frontend formatting issue.

The source was the Curve-like Convex path in `getCVXPoolAPY`: it read Convex `rewardRate` and `totalSupply`, but did not check `periodFinish`. For pools where the rewards period had expired, a stale nonzero `rewardRate` could still be annualized against a small remaining Convex supply, producing a massively inflated forward APR/APY.

## Fix
`getCVXPoolAPY` now reads `periodFinish` from the Convex rewards contract and returns zero APR/APY when the rewards period is expired.

## Test plan
- [x] `corepack yarn test src/crv-like.forward.test.ts`
- [x] `corepack yarn build`
- [x] `./node_modules/.bin/eslint src/crv-like.forward.ts src/crv-like.forward.test.ts`

Notes:
- Scoped lint passes with existing warnings in untouched code.
- The full test suite has live/RPC-sensitive failures unrelated to this change.
- Full `yarn lint` also scans build-emitted `public/*.js` files and reports existing generated JS lint errors.
