### PR TITLE
feat: add OpenTelemetry error reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ KONG_SECRET=dev-fapy-key
 PORT=3030
 CRV_GAUGE_REGISTRY_URL=https://api.curve.finance/api/getAllGauges
 CRV_POOLS_URL=https://api.curve.finance/api/getPools/all
+
+# OpenTelemetry error reporting. Leave the endpoint unset to disable.
+# Point at any OTLP/HTTP backend (Sentry OTLP, Grafana, Honeycomb, an OTel Collector, ...).
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_SERVICE_NAME=fapy-hook

--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -1,3 +1,4 @@
+import { captureError, flushObservability } from '../src/observability';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import 'dotenv/config';
 import { createHmac, timingSafeEqual } from 'node:crypto';
@@ -74,6 +75,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ error: 'invalid payload', issues: err.issues });
     }
+    captureError(err);
+    await flushObservability();
     return res.status(500).json({ error: 'internal error' });
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
   },
   "dependencies": {
     "@ethersproject/bignumber": "5.8.0",
+    "@opentelemetry/api-logs": "0.219.0",
+    "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-logs": "0.219.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
     "dotenv": "16.6.1",
     "express": "4.21.2",
     "js-big-decimal": "2.2.0",

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,53 @@
+import 'dotenv/config';
+import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+  ATTR_SERVICE_NAME,
+} from '@opentelemetry/semantic-conventions';
+
+const SERVICE_NAME = 'fapy-hook';
+
+const endpoint =
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+
+let provider: LoggerProvider | undefined;
+
+// Reporting is a no-op until an OTLP endpoint is configured via the standard
+// OTEL_EXPORTER_OTLP_* env vars. Point it at any OTLP-compatible backend.
+if (endpoint) {
+  provider = new LoggerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || SERVICE_NAME,
+    }),
+    processors: [new BatchLogRecordProcessor(new OTLPLogExporter())],
+  });
+  logs.setGlobalLoggerProvider(provider);
+}
+
+export function captureError(error: unknown): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const attributes: Record<string, string> = {
+    [ATTR_EXCEPTION_TYPE]: err.name,
+    [ATTR_EXCEPTION_MESSAGE]: err.message,
+  };
+  if (err.stack) {
+    attributes[ATTR_EXCEPTION_STACKTRACE] = err.stack;
+  }
+
+  logs.getLogger(SERVICE_NAME).emit({
+    severityNumber: SeverityNumber.ERROR,
+    severityText: 'ERROR',
+    body: err.message,
+    attributes,
+  });
+}
+
+// Serverless functions may freeze before batched logs export; flush after capture.
+export async function flushObservability(): Promise<void> {
+  await provider?.forceFlush();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,96 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@opentelemetry/api-logs@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz#3303f10f43e6ff1741f8f6019e43a92723781630"
+  integrity sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/core@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
+  integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-logs-otlp-http@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.219.0.tgz#3a4764ec408efdf9c573cfc3e4ffc41392694d3b"
+  integrity sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+
+"@opentelemetry/otlp-exporter-base@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz#68f4908f45f6df577d8e1c5b42761645f01cffc5"
+  integrity sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+
+"@opentelemetry/otlp-transformer@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz#86305b29f564220666f6e410b7eded57bb5e6c3a"
+  integrity sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/resources@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.8.0.tgz#9bcb658ab6254f33099f4a95544b40d6f53cc946"
+  integrity sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-logs@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz#002433237908d24fa9e7f17eb4963f25f03d655c"
+  integrity sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-metrics@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz#c3f908d9e7e02fb855673fcfd4b298ce279e61f1"
+  integrity sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+
+"@opentelemetry/sdk-trace-base@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz#ec9c1d69e2e6fba256c9df0c8e8d67d42386d52b"
+  integrity sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/semantic-conventions@1.41.1", "@opentelemetry/semantic-conventions@^1.29.0":
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz#b04e7151c5913a7a006d4f465479da75efb98a7a"
+  integrity sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"


### PR DESCRIPTION
### Summary
Report errors from the Vercel serverless functions as OpenTelemetry log records over OTLP/HTTP, using only `@opentelemetry/*` packages. Vendor-neutral: point `OTEL_EXPORTER_OTLP_ENDPOINT` (and `OTEL_EXPORTER_OTLP_HEADERS` for auth) at any OTLP backend — Grafana, Honeycomb, an OpenTelemetry Collector, or a hosted OTLP service. No-op until configured.

### How to review
- `src/observability.ts`: at module load it builds a `LoggerProvider` with an OTLP/HTTP log exporter (configured from the standard `OTEL_EXPORTER_OTLP_*` env vars, skipped when unset); `captureError` emits an ERROR log record with `exception.*` semantic attributes; `flushObservability` force-flushes before the function freezes.
- `api/webhook.ts` imports it on cold start. The unexpected-error branch (500) calls `captureError` then `await flushObservability`; Zod validation errors stay a 400 and are not reported.

### Test plan
- [ ] Manual: set `OTEL_EXPORTER_OTLP_ENDPOINT` (+ `OTEL_EXPORTER_OTLP_HEADERS`), POST a payload that hits the 500 branch, confirm the log record reaches the backend.
- [ ] Manual: leave the endpoint unset, confirm nothing is exported and responses are unchanged.
- [ ] Automated: `yarn build` (tsc) passes; webhook handler tests in `src/batch-webhook.test.ts` pass. Note: 2 live-data tests in `src/fapy.test.ts` fail on this branch and on the base branch alike (network/value drift) — unrelated to this change.

### Risk / impact
Low. With the OTLP endpoint unset (the default), reporting is a no-op and behavior is unchanged. No funds, auth, or migration paths touched.
